### PR TITLE
fix for compilation errors with find

### DIFF
--- a/examples/sandia_decay_example.cpp
+++ b/examples/sandia_decay_example.cpp
@@ -31,6 +31,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <assert.h>
+#include <algorithm>
 
 #include "SandiaDecay.h"
 

--- a/tools/minimize_xml_file.cpp
+++ b/tools/minimize_xml_file.cpp
@@ -26,6 +26,7 @@
 #include <sstream>
 #include <fstream>
 #include <iterator>
+#include <algorithm>
 
 #include "SandiaDecay.h"
 


### PR DESCRIPTION
I had to include <algorithm> to complete compilation on linux with gcc 9.1