### PR TITLE
Use NuclideNumAtoms pair to calculate aged nuclide mixture. Fixes #6

### DIFF
--- a/SandiaDecay.cpp
+++ b/SandiaDecay.cpp
@@ -1606,23 +1606,11 @@ void NuclideMixture::addAgedNuclideByActivity( const Nuclide *nuclide,
 {
   NuclideMixture ager;
   ager.addNuclideByActivity( nuclide, activity );
-  const std::vector<NuclideActivityPair> aged_activities = ager.activity( age );
-
-  double age_sf = 1.0;
-  for( size_t i = 0; i < aged_activities.size(); ++i )
+  const std::vector<NuclideNumAtomsPair> aged_atoms = ager.numAtoms( age );
+  for( size_t i = 0; i < aged_atoms.size(); ++i )
   {
-    const NuclideActivityPair &red = aged_activities[i];
-    if( red.nuclide == nuclide )
-    {
-      age_sf = activity / red.activity;
-      i = aged_activities.size();
-    }
-  }//for( size_t i = 0; i < aged_activities.size(); ++i )
-
-  for( size_t i = 0; i < aged_activities.size(); ++i )
-  {
-    const NuclideActivityPair &red = aged_activities[i];
-    addNuclideByActivity( red.nuclide, age_sf * red.activity );
+    const NuclideNumAtomsPair &red = aged_atoms[i];
+    addNuclideByAbundance( red.nuclide, red.numAtoms );
   }
 }//void addAgedNuclideByActivity(...)
 


### PR DESCRIPTION
Hi I noticed that the calculations for mixtures when adding nuclide by the `addAgedNuclideByActivity` vs `addNuclideByActivity` are different.

Please correct me if I'm wrong, but my assumption is that these calls should generate the exact same results:
```mix.addAgedNuclideByActivity(n, act, time); num = mix.numAtoms(0.0);```

```mix.addNuclideByActivity(n, act); num = mix.numAtoms(time);```



I used `NuclideNumAtomsPair` instead of  `NuclideActivityPair`  as stable nuclides will not have activity.
Also I'm not sure what the significance of the scaling factor is/was so I just removed it.

Issue #6 

Code to reproduce:
```
#include "SandiaDecay/SandiaDecay.h"
#include <cstdio>

using namespace SandiaDecay;

int main(int arg, char * argv[]) {
   SandiaDecayDataBase db(argv[1]);
   const Nuclide * n = db.nuclide("Co60");
   const Nuclide * n2 = db.nuclide("Ni60");
   const double act = 10.0f;
   const double time = 10000.0f;

   NuclideMixture mix;
   NuclideMixture mix2;
   mix.addNuclideByActivity(n, act);
   mix2.addAgedNuclideByActivity(n, act, time);
   printf("Mix1: Co60: %lf, Ni60: %lf\n", mix.numAtoms(time, n), mix.numAtoms(time, n2));
   printf("Mix2: Co60: %lf, Ni60: %lf\n", mix2.numAtoms(0.0, n), mix2.numAtoms(0.0, n2));
   return 0;
}
```

Old Output:
```
Mix1: Co60: 2399736640.899784, Ni60: 99997.916553
Mix2: Co60: 2399836638.816338, Ni60: 0.000000
```

New Output:
```
Mix1: Co60: 2399736640.899784, Ni60: 99997.916553
Mix2: Co60: 2399736640.899784, Ni60: 99997.916553
```